### PR TITLE
Closes #29 Document database options for experiment metadata

### DIFF
--- a/__play7/CheckPalindrome.php
+++ b/__play7/CheckPalindrome.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Checks if a string is a palindrome
+ *
+ * @param string $string
+ * @param bool $caseInsensitive
+ * @return bool
+ */
+function isPalindrome(string $string, bool $caseInsensitive = true)
+{
+    $string = trim($string); // Removing leading and trailing spaces
+
+    if (empty($string)) {
+        return false; // Returning false for an Empty String
+    }
+
+    if ($caseInsensitive) {
+        $string = strtolower($string); // Converting string to lowercase for case-insensitive check
+    }
+
+    $characters = str_split($string);
+
+    for ($i = 0; $i < count($characters); $i++) {
+        if ($characters[$i] !== $characters[count($characters) - ($i + 1)]) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/__play7/FindSecondLargestElement.js
+++ b/__play7/FindSecondLargestElement.js
@@ -1,0 +1,25 @@
+/*
+ * Find Second Largest is a real technical interview question.
+ * Chances are you will be asked to find the second largest value
+ * inside of an array of numbers. You must also be able to filter
+ * out duplicate values.  It's important to know how to do this with
+ * clean code that is also easy to explain.
+ *
+ * Resources:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+ */
+
+const secondLargestElement = (array) => {
+  const largestElement = Math.max(...array)
+  let element = -Number.MAX_VALUE
+
+  for (let i = 0; i < array.length; i++) {
+    if (element < array[i] && array[i] !== largestElement) {
+      element = array[i]
+    }
+  }
+
+  return element
+}
+
+export { secondLargestElement }

--- a/__play7/QuickSortTest.kt
+++ b/__play7/QuickSortTest.kt
@@ -1,0 +1,31 @@
+package sort
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class QuickSortTest {
+
+    @Test
+    fun testQuickSort1() {
+        val array = arrayOf(4, 3, 2, 8, 1)
+        quickSort(array, 0, array.size - 1)
+
+        assertArrayEquals(array, arrayOf(1, 2, 3, 4, 8))
+    }
+
+    @Test
+    fun testQuickSort2() {
+        val array = arrayOf("A", "D", "E", "C", "B")
+        quickSort(array, 0, array.size - 1)
+
+        assertArrayEquals(array, arrayOf("A", "B", "C", "D", "E"))
+    }
+
+    @Test
+    fun testQuickSort3() {
+        val array = arrayOf(20, 5, 16, -1, 6)
+        quickSort(array, 0, array.size - 1)
+
+        assertArrayEquals(array, arrayOf(-1, 5, 6, 16, 20))
+    }
+}

--- a/__play7/abs.jule
+++ b/__play7/abs.jule
@@ -1,0 +1,6 @@
+fn Abs(mut n: f64): f64 {
+	if n < 0 {
+		n = -n
+	}
+	ret n
+}

--- a/__play7/binary_search.ts
+++ b/__play7/binary_search.ts
@@ -1,0 +1,64 @@
+/**
+ * @function binarySearch
+ * @description binary search algorithm (iterative & recursive implementations) for a sorted array.
+ *
+ * The algorithm searches for a specific value in a sorted array in logarithmic time.
+ * It repeatedly halves the portion of the list that could contain the item,
+ * until you've narrowed down the possible indices to just one.
+ *
+ * @param {number[]} array - sorted list of numbers
+ * @param {number} target - target number to search for
+ * @return {number} - index of the target number in the list, or null if not found
+ * @see [BinarySearch](https://www.geeksforgeeks.org/binary-search/)
+ * @example binarySearch([1,2,3], 2) => 1
+ * @example binarySearch([4,5,6], 2) => null
+ */
+
+export const binarySearchIterative = (
+  array: number[],
+  target: number,
+  start: number = 0,
+  end: number = array.length - 1
+): number | null => {
+  if (array.length === 0) return null
+
+  // ensure the target is within the bounds of the array
+  if (target < array[start] || target > array[end]) return null
+
+  // declare pointers for the middle index
+  let middle = (start + end) >> 1
+
+  while (array[middle] !== target && start <= end) {
+    // if the target is less than the middle value, move the end pointer to be middle -1 to narrow the search space
+    // otherwise, move the start pointer to be middle + 1
+    if (target < array[middle]) end = middle - 1
+    else start = middle + 1
+    // redeclare the middle index when the search window changes
+    middle = (start + end) >> 1
+  }
+  // return the middle index if it is equal to target
+  return array[middle] === target ? middle : null
+}
+
+export const binarySearchRecursive = (
+  array: number[],
+  target: number,
+  start = 0,
+  end = array.length - 1
+): number | null => {
+  if (array.length === 0) return null
+
+  // ensure the target is within the bounds of the array
+  if (target < array[start] || target > array[end]) return null
+
+  const middle = (start + end) >> 1
+
+  if (array[middle] === target) return middle // target found
+  if (start > end) return null // target not found
+
+  // if the target is less than the middle value, move the end pointer to be middle -1 to narrow the search space
+  // otherwise, move the start pointer to be middle + 1
+  return target < array[middle]
+    ? binarySearchRecursive(array, target, start, middle - 1)
+    : binarySearchRecursive(array, target, middle + 1, end)
+}

--- a/__play7/is_sorted.lua
+++ b/__play7/is_sorted.lua
@@ -1,0 +1,20 @@
+return function(
+	list,
+	-- function(a, b) -> truthy value if a < b
+	less_than
+)
+	less_than = less_than or function(a, b)
+		return a < b
+	end
+	for i = 2, #list do
+		-- Check whether an element is smaller than it's predecessor;
+		-- If all elements are less than or equal to their predecessor, the list must be sorted
+		-- due to the transitivity of the comparison operator
+		if less_than(list[i], list[i - 1]) then
+			-- list is not sorted ascendingly
+			return false
+		end
+	end
+	-- list is sorted ascendingly
+	return true
+end

--- a/__play7/sha1.go
+++ b/__play7/sha1.go
@@ -1,0 +1,110 @@
+// sha1.go
+// description: The SHA-1 hashing function as defined in RFC 3174.
+// author: Simon Waldherr
+// ref: https://datatracker.ietf.org/doc/html/rfc3174
+// see sha1_test.go for testing
+
+package sha1
+
+import (
+	"encoding/binary" // Used for interacting with uint at the byte level
+)
+
+// Constants for SHA-1
+const (
+	h0 uint32 = 0x67452301
+	h1 uint32 = 0xEFCDAB89
+	h2 uint32 = 0x98BADCFE
+	h3 uint32 = 0x10325476
+	h4 uint32 = 0xC3D2E1F0
+)
+
+// pad pads the input message so that its length is congruent to 448 modulo 512
+func pad(message []byte) []byte {
+	originalLength := len(message) * 8
+	message = append(message, 0x80)
+	for (len(message)*8)%512 != 448 {
+		message = append(message, 0x00)
+	}
+
+	lengthBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(lengthBytes, uint64(originalLength))
+	message = append(message, lengthBytes...)
+
+	return message
+}
+
+// leftRotate rotates x left by n bits
+func leftRotate(x, n uint32) uint32 {
+	return (x << n) | (x >> (32 - n))
+}
+
+// Hash computes the SHA-1 hash of the input message
+func Hash(message []byte) [20]byte {
+	message = pad(message)
+
+	// Initialize variables
+	a, b, c, d, e := h0, h1, h2, h3, h4
+
+	// Process the message in successive 512-bit chunks
+	for i := 0; i < len(message); i += 64 {
+		var w [80]uint32
+		chunk := message[i : i+64]
+
+		// Break chunk into sixteen 32-bit big-endian words
+		for j := 0; j < 16; j++ {
+			w[j] = binary.BigEndian.Uint32(chunk[j*4 : (j+1)*4])
+		}
+
+		// Extend the sixteen 32-bit words into eighty 32-bit words
+		for j := 16; j < 80; j++ {
+			w[j] = leftRotate(w[j-3]^w[j-8]^w[j-14]^w[j-16], 1)
+		}
+
+		// Initialize hash value for this chunk
+		A, B, C, D, E := a, b, c, d, e
+
+		// Main loop
+		for j := 0; j < 80; j++ {
+			var f, k uint32
+			switch {
+			case j < 20:
+				f = (B & C) | ((^B) & D)
+				k = 0x5A827999
+			case j < 40:
+				f = B ^ C ^ D
+				k = 0x6ED9EBA1
+			case j < 60:
+				f = (B & C) | (B & D) | (C & D)
+				k = 0x8F1BBCDC
+			default:
+				f = B ^ C ^ D
+				k = 0xCA62C1D6
+			}
+
+			temp := leftRotate(A, 5) + f + E + k + w[j]
+			E = D
+			D = C
+			C = leftRotate(B, 30)
+			B = A
+			A = temp
+		}
+
+		// Add this chunk's hash to result so far
+		a += A
+		b += B
+		c += C
+		d += D
+		e += E
+	}
+
+	// Produce the final hash value (digest)
+	var digest [20]byte
+	binary.BigEndian.PutUint32(digest[0:4], a)
+	binary.BigEndian.PutUint32(digest[4:8], b)
+	binary.BigEndian.PutUint32(digest[8:12], c)
+	binary.BigEndian.PutUint32(digest[12:16], d)
+	binary.BigEndian.PutUint32(digest[16:20], e)
+
+	return digest
+}


### PR DESCRIPTION
29 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.